### PR TITLE
Fix parser to work with empty lines after EOF

### DIFF
--- a/src/cz/jaybee/intelhex/Parser.java
+++ b/src/cz/jaybee/intelhex/Parser.java
@@ -217,6 +217,10 @@ public class Parser {
         String recordStr;
 
         while ((recordStr = reader.readLine()) != null) {
+            // Ignore if this is a blank line.
+            if (recordStr.isEmpty()) {
+                continue;
+            }
             Record record = parseRecord(recordStr);
             processRecord(record);
             recordIdx++;


### PR DESCRIPTION
An exception (data after EOF) was thrown everytime a empty line appears after the EOF record.

Some Intel Hex files do have an extra blank line which couldn't be used with this parser.

Appling this fix, the parser will ignore the record if it's an empty line.