### PR TITLE
Parser: fix parsing problem for length as minus

### DIFF
--- a/src/cz/jaybee/intelhex/Parser.java
+++ b/src/cz/jaybee/intelhex/Parser.java
@@ -107,7 +107,11 @@ public class Parser {
         }
 
         // if the length field does not correspond with line length
-        result.length = hexRecord[0];
+        if (hexRecord[0] < 0) // FIX #7( https://github.com/j123b567/java-intelhex-parser/issues/7) ':FF02000048474645444353525150...' -> hexRecord[0] = -1
+            result.length = (int) hexRecord[0] + 256;
+        else
+            result.length = (int) hexRecord[0];
+
         if ((result.length + 5) != hexRecord.length) {
             throw new IntelHexException("Invalid record length (" + recordIdx + ")");
         }


### PR DESCRIPTION
If record has a FF length, then Parser recognize it as -1
So casting is needed for these kind of cases

this closes #7